### PR TITLE
Dev

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,6 +10,10 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        os: [win10, linux, osx]
+      fail-fast: true
     runs-on: windows-latest
     steps:
     - name: Check Tag
@@ -45,7 +49,7 @@ jobs:
 
     - name: Build & Zip
       shell: pwsh
-      run: .\createpublishedzip.ps1
+      run: .\createpublishedzip.ps1 -os ${{ matrix.os }}
 
     - name: Publish to Github
       uses: ncipollo/release-action@v1
@@ -56,3 +60,4 @@ jobs:
         artifactErrorsFailBuild: true
         draft: true
         allowUpdates: true
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "external/FluentAvalonia"]
-	path = external/FluentAvalonia
-	url = https://github.com/PhantomGamers/FluentAvalonia
-    branch = patch-3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "external/FluentAvalonia"]
+	path = external/FluentAvalonia
+	url = https://github.com/PhantomGamers/FluentAvalonia.git
+	branch = improve-theme-detection

--- a/SFP.sln
+++ b/SFP.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		SFPCommon.props = SFPCommon.props
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentAvalonia", "external\FluentAvalonia\FluentAvalonia\FluentAvalonia.csproj", "{65BB4EA0-1B9E-473C-A683-98AF9CAC856F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{2801B18E-31FC-4B99-AAD7-7259CD197D8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2801B18E-31FC-4B99-AAD7-7259CD197D8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2801B18E-31FC-4B99-AAD7-7259CD197D8D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65BB4EA0-1B9E-473C-A683-98AF9CAC856F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65BB4EA0-1B9E-473C-A683-98AF9CAC856F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65BB4EA0-1B9E-473C-A683-98AF9CAC856F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65BB4EA0-1B9E-473C-A683-98AF9CAC856F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SFP.sln
+++ b/SFP.sln
@@ -13,8 +13,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		SFPCommon.props = SFPCommon.props
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentAvalonia", "external\FluentAvalonia\FluentAvalonia\FluentAvalonia.csproj", "{7923CB41-588A-4B91-9C24-3A71B5B0E25D}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,10 +27,6 @@ Global
 		{2801B18E-31FC-4B99-AAD7-7259CD197D8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2801B18E-31FC-4B99-AAD7-7259CD197D8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2801B18E-31FC-4B99-AAD7-7259CD197D8D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7923CB41-588A-4B91-9C24-3A71B5B0E25D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7923CB41-588A-4B91-9C24-3A71B5B0E25D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7923CB41-588A-4B91-9C24-3A71B5B0E25D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7923CB41-588A-4B91-9C24-3A71B5B0E25D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SFP/Models/ChromeCache/BlockFile/Parser.cs
+++ b/SFP/Models/ChromeCache/BlockFile/Parser.cs
@@ -46,7 +46,8 @@ namespace SFP.ChromeCache.BlockFile
                     var entry = new EntryStore(new Addr(raw, cacheDir.FullName));
                     while (entry.next != 0)
                     {
-                        if (entry.Key.Contains(fileName))
+                        // TODO: Investigate to see whether this should be >= 2 or if we should just add the last entry in the array
+                        if (entry.Key.Contains(fileName) && entry.data_addrs.Count >= 2)
                         {
                             files.Add(entry.data_addrs[1].File);
                         }

--- a/SFP/Models/ChromeCache/BlockFile/Patcher.cs
+++ b/SFP/Models/ChromeCache/BlockFile/Patcher.cs
@@ -6,7 +6,7 @@ namespace SFP.ChromeCache.BlockFile
     public class Patcher
     {
         private static MemoryCache s_memCache;
-        private static readonly TimeSpan s_cacheTimeSpan = TimeSpan.FromSeconds(Properties.Settings.Default.ScannerDelay);
+        private static TimeSpan s_cacheTimeSpan => TimeSpan.FromSeconds(Properties.Settings.Default.ScannerDelay);
 
         static Patcher()
         {

--- a/SFP/Models/ChromeCache/BlockFile/Structs.cs
+++ b/SFP/Models/ChromeCache/BlockFile/Structs.cs
@@ -11,6 +11,7 @@ namespace SFP.ChromeCache.BlockFile
         public readonly uint next = 0;
         public readonly List<Addr> data_addrs = new();
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeSmell", "ERP022:Unobserved exception in generic exception handler", Justification = "Can error with corrupted cache")]
         public EntryStore(Addr addr)
         {
             FileInfo? tmpFile = LinkModel.GetLink(addr.File);
@@ -33,9 +34,8 @@ namespace SFP.ChromeCache.BlockFile
                 {
                     data_addrs.Add(new Addr(raw, addr.File.DirectoryName!));
                 }
-                catch (Exception e)
+                catch
                 {
-                    LogModel.Logger.Debug(e);
                     continue;
                 }
             }

--- a/SFP/Models/LocalFileModel.cs
+++ b/SFP/Models/LocalFileModel.cs
@@ -12,7 +12,7 @@ namespace SFP
 
         private static MemoryCache s_libraryMemCache;
 
-        private static readonly TimeSpan s_cacheTimeSpan = TimeSpan.FromSeconds(Properties.Settings.Default.ScannerDelay);
+        private static TimeSpan s_cacheTimeSpan => TimeSpan.FromSeconds(Properties.Settings.Default.ScannerDelay);
 
         static LocalFileModel()
         {

--- a/SFP/Properties/Settings.Designer.cs
+++ b/SFP/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace SFP.Properties {
 
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.3.0.0")]
     public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
 
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -228,6 +228,19 @@ namespace SFP.Properties {
             }
             set {
                 this["ScannerDelay"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("System Default")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public string AppTheme {
+            get {
+                return ((string)(this["AppTheme"]));
+            }
+            set {
+                this["AppTheme"] = value;
             }
         }
     }

--- a/SFP/Properties/Settings.Designer.cs
+++ b/SFP/Properties/Settings.Designer.cs
@@ -243,5 +243,18 @@ namespace SFP.Properties {
                 this["AppTheme"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public bool CloseToTray {
+            get {
+                return ((bool)(this["CloseToTray"]));
+            }
+            set {
+                this["CloseToTray"] = value;
+            }
+        }
     }
 }

--- a/SFP/Properties/Settings.settings
+++ b/SFP/Properties/Settings.settings
@@ -50,5 +50,8 @@
     <Setting Name="ScannerDelay" Roaming="true" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">2</Value>
     </Setting>
+    <Setting Name="AppTheme" Roaming="true" Type="System.String" Scope="User">
+      <Value Profile="(Default)">System Default</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/SFP/Properties/Settings.settings
+++ b/SFP/Properties/Settings.settings
@@ -53,5 +53,8 @@
     <Setting Name="AppTheme" Roaming="true" Type="System.String" Scope="User">
       <Value Profile="(Default)">System Default</Value>
     </Setting>
+    <Setting Name="CloseToTray" Roaming="true" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/SFP_UI/App.axaml
+++ b/SFP_UI/App.axaml
@@ -7,10 +7,6 @@
         <local:ViewLocator/>
     </Application.DataTemplates>
 
-    <Application.Resources>
-        <Thickness x:Key="NavigationViewContentMargin">0,48,0,0</Thickness>
-    </Application.Resources>
-
     <Application.Styles>
         <sty:FluentAvaloniaTheme />
         <StyleInclude Source="avares://Notification.Avalonia/Themes/Generic.xaml" />

--- a/SFP_UI/App.axaml.cs
+++ b/SFP_UI/App.axaml.cs
@@ -71,6 +71,7 @@ namespace SFP_UI
         {
             LinkModel.RemoveAllHardLinks();
             FSWModel.RemoveAllWatchers();
+            Models.ThemeChangeDetection.Linux.MonitorProcess?.Kill();
         }
     }
 }

--- a/SFP_UI/Models/ThemeChangeDetection/Linux.cs
+++ b/SFP_UI/Models/ThemeChangeDetection/Linux.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+using Avalonia.Threading;
+
 using FluentAvalonia.Core;
 using FluentAvalonia.Styling;
 
@@ -37,11 +39,15 @@ namespace SFP_UI.Models.ThemeChangeDetection
                                                                  {
                                                                      if (!MainWindow.IsValidRequestedTheme(SFP.Properties.Settings.Default.AppTheme))
                                                                      {
-                                                                         MainWindow.Instance?.Theme?.InvalidateThemingFromSystemThemeChanged();
+                                                                         _ = Dispatcher.UIThread.InvokeAsync(() =>
+                                                                         {
+                                                                             MainWindow.Instance?.Theme?.InvalidateThemingFromSystemThemeChanged();
+                                                                         });
                                                                      }
                                                                  };
                                                                  MonitorProcess = process;
                                                                  process.Start();
+                                                                 process.BeginOutputReadLine();
                                                              }
                                                              catch
                                                              {

--- a/SFP_UI/Models/ThemeChangeDetection/Linux.cs
+++ b/SFP_UI/Models/ThemeChangeDetection/Linux.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using FluentAvalonia.Core;
+using FluentAvalonia.Styling;
+
+using SFP_UI.Views;
+
+namespace SFP_UI.Models.ThemeChangeDetection
+{
+    internal class Linux
+    {
+        public static Process? MonitorProcess { get; private set; }
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeSmell", "ERP022:Unobserved exception in generic exception handler", Justification = "Unsupported on some platforms")]
+        public static void WatchForChanges() => _ = Task.Run(() =>
+                                                         {
+                                                             try
+                                                             {
+                                                                 Process process = new()
+                                                                 {
+                                                                     StartInfo = new ProcessStartInfo
+                                                                     {
+                                                                         WindowStyle = ProcessWindowStyle.Hidden,
+                                                                         CreateNoWindow = true,
+                                                                         UseShellExecute = false,
+                                                                         RedirectStandardError = true,
+                                                                         RedirectStandardOutput = true,
+                                                                         FileName = "gsettings",
+                                                                         Arguments = "monitor org.gnome.desktop.interface gtk-theme",
+                                                                     },
+                                                                 };
+                                                                 process.OutputDataReceived += (sender, args) =>
+                                                                 {
+                                                                     if (!MainWindow.IsValidRequestedTheme(SFP.Properties.Settings.Default.AppTheme))
+                                                                     {
+                                                                         MainWindow.Instance?.Theme?.InvalidateThemingFromSystemThemeChanged();
+                                                                     }
+                                                                 };
+                                                                 MonitorProcess = process;
+                                                                 process.Start();
+                                                             }
+                                                             catch
+                                                             {
+                                                                 SFP.LogModel.Logger.Warn("Unable to detect system theme changes on this platform.");
+                                                             }
+                                                         });
+    }
+}

--- a/SFP_UI/Models/ThemeChangeDetection/Linux.cs
+++ b/SFP_UI/Models/ThemeChangeDetection/Linux.cs
@@ -1,10 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 using Avalonia.Threading;
 
 using FluentAvalonia.Core;

--- a/SFP_UI/Models/UpdateCheckModel.cs
+++ b/SFP_UI/Models/UpdateCheckModel.cs
@@ -66,7 +66,6 @@ namespace SFP_UI.Models
             {
                 if (theme.TryGetResource("AccentFillColorSelectedTextBackgroundBrush", out object? accentColor))
                 {
-                    LogModel.Logger.Info("accentColor");
                     builder.Message.AccentBrush = (IBrush)accentColor;
                 }
                 else
@@ -76,7 +75,6 @@ namespace SFP_UI.Models
 
                 if (theme.TryGetResource("SolidBackgroundFillColorBaseBrush", out object? backgroundColor))
                 {
-                    LogModel.Logger.Info("backgroundColor");
                     builder.Message.Background = (IBrush)backgroundColor;
                 }
                 else
@@ -86,7 +84,6 @@ namespace SFP_UI.Models
 
                 if (theme.TryGetResource("DefaultTextForegroundThemeBrush", out object? foregroundColor))
                 {
-                    LogModel.Logger.Info("foregroundColor");
                     builder.Message.Foreground = (IBrush)foregroundColor;
                 }
             }

--- a/SFP_UI/Pages/MainPage.axaml
+++ b/SFP_UI/Pages/MainPage.axaml
@@ -4,7 +4,7 @@
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              x:Class="SFP_UI.Pages.MainPage">
   <Grid>
-    <DockPanel Margin="10">
+    <DockPanel Margin="16">
       <DockPanel DockPanel.Dock="Bottom" Margin="15 0 0 0">
           <Button Margin="0 0 10 0"
                   IsEnabled="{Binding ButtonsEnabled}"

--- a/SFP_UI/Pages/MainPage.axaml
+++ b/SFP_UI/Pages/MainPage.axaml
@@ -14,7 +14,7 @@
                   IsEnabled="{Binding ButtonsEnabled}"
                   IsVisible="{Binding !ScannerActive}"
                   Command="{Binding OnScanCommand}"
-                  ToolTip.Tip="Starts scanning for changes to Steam, repatching as needed based on your settings">Start Scanner</Button>
+                  ToolTip.Tip="Starts scanning for changes to Steam, repatching as needed based on your settings">Start scanner</Button>
           <Button Margin="0 0 10 0"
                   IsEnabled="{Binding ButtonsEnabled}"
                   IsVisible="{Binding ScannerActive}"

--- a/SFP_UI/Pages/SettingsPage.axaml
+++ b/SFP_UI/Pages/SettingsPage.axaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="SFP_UI.Pages.SettingsPage">
 
-  <DockPanel Margin="15">
+  <DockPanel Margin="16">
     <StackPanel Orientation="Horizontal" Spacing="15" DockPanel.Dock="Bottom" Margin="0 15 0 0">
       <Button Command="{Binding OnSaveCommand}"
               ToolTip.Tip="Saves your settings to config">Save</Button>
@@ -10,8 +10,9 @@
               ToolTip.Tip="Reloads settings from config">Reload</Button>
     </StackPanel>
     <ScrollViewer>
-      <StackPanel Orientation="Vertical" Spacing="4">
-        <Label Margin="8">Steam Settings</Label>
+      <StackPanel Orientation="Vertical">
+
+        <TextBlock Text="Steam" Classes="BodyStrongTextBlockStyle"/>
         <StackPanel Orientation="Horizontal" Spacing="4">
           <Label Margin="0,10">Steam Launch Args</Label>
           <TextBox Watermark="Steam launch args (e.g. -dev)" VerticalContentAlignment="Center" Width="220" Text="{Binding SteamLaunchArgs}"/>
@@ -33,25 +34,29 @@
           <Button Margin="5,0,0,0" Command="{Binding OnResetCacheCommand}">Reset</Button>
         </StackPanel>
         <CheckBox IsChecked="{Binding RestartSteamOnPatch}">Restart Steam On Patch</CheckBox>
-        <Label Margin="8">Patcher Settings</Label>
+
+        <TextBlock Text="Patcher" Margin="0 20 0 4" Classes="BodyStrongTextBlockStyle"/>
         <CheckBox IsChecked="{Binding ShouldPatchOnStart}">Patch On App Startup</CheckBox>
         <CheckBox IsChecked="{Binding ShouldPatchFriends}">Patch Friends</CheckBox>
         <CheckBox IsChecked="{Binding ShouldPatchLibrary}">Patch Library</CheckBox>
         <CheckBox IsChecked="{Binding ScanOnly}">Scan Only</CheckBox>
-        <Label Margin="8">Scanner Settings</Label>
+
+        <TextBlock Text="Scanner" Margin="0 20 0 4" Classes="BodyStrongTextBlockStyle"/>
         <CheckBox IsChecked="{Binding ShouldScanOnStart}">Scan On App Startup</CheckBox>
         <CheckBox IsChecked="{Binding ShouldScanFriends}">Scan Friends</CheckBox>
         <CheckBox IsChecked="{Binding ShouldScanLibrary}">Scan Library</CheckBox>
         <StackPanel Orientation="Horizontal" Margin="0,5" Spacing="4">
-            <Label Margin="0,10">Scanner Delay (Seconds)</Label>
+            <Label>Scanner Delay (Seconds)</Label>
             <NumericUpDown Value="{Binding ScannerDelay}" Increment="1" Minimum="1" Maximum="10" Width="110" Height="20" HorizontalContentAlignment="Center"/>
         </StackPanel>
-        <Label Margin="8">General Settings</Label>
+
+        <TextBlock Text="General" Margin="0 20 0 4" Classes="BodyStrongTextBlockStyle"/>
         <CheckBox IsChecked="{Binding CheckForUpdates}">Check For Updates On Startup</CheckBox>
         <CheckBox IsChecked="{Binding ShowTrayIcon}">Show Tray Icon</CheckBox>
         <CheckBox IsChecked="{Binding MinimizeToTray}">Minimize To Tray</CheckBox>
         <CheckBox IsChecked="{Binding StartMinimized}">Start Minimized</CheckBox>
         <!-- <CheckBox IsChecked="{Binding StartWithOS}">Start With OS</CheckBox> -->
+
       </StackPanel>
     </ScrollViewer>
   </DockPanel>

--- a/SFP_UI/Pages/SettingsPage.axaml
+++ b/SFP_UI/Pages/SettingsPage.axaml
@@ -56,6 +56,12 @@
         <CheckBox IsChecked="{Binding MinimizeToTray}">Minimize To Tray</CheckBox>
         <CheckBox IsChecked="{Binding StartMinimized}">Start Minimized</CheckBox>
         <!-- <CheckBox IsChecked="{Binding StartWithOS}">Start With OS</CheckBox> -->
+        <Label>App Theme</Label>
+        <ComboBox Name="AppThemeComboBox" Width="141" SelectedIndex="2">
+            <ComboBoxItem>Dark</ComboBoxItem>
+            <ComboBoxItem>Light</ComboBoxItem>
+            <ComboBoxItem>System Default</ComboBoxItem>
+        </ComboBox>
 
       </StackPanel>
     </ScrollViewer>

--- a/SFP_UI/Pages/SettingsPage.axaml
+++ b/SFP_UI/Pages/SettingsPage.axaml
@@ -1,5 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ui="using:FluentAvalonia.UI.Controls"
              x:Class="SFP_UI.Pages.SettingsPage">
 
   <DockPanel Margin="16">
@@ -62,6 +63,7 @@
             <ComboBoxItem>Light</ComboBoxItem>
             <ComboBoxItem>System Default</ComboBoxItem>
         </ComboBox>
+        <ui:HyperlinkButton Content="Windows color settings" NavigateUri="ms-settings:colors" IsVisible="{Binding s_isWindows}"/>
 
       </StackPanel>
     </ScrollViewer>

--- a/SFP_UI/Pages/SettingsPage.axaml
+++ b/SFP_UI/Pages/SettingsPage.axaml
@@ -14,7 +14,7 @@
       <StackPanel Orientation="Vertical">
 
         <TextBlock Text="Steam" Classes="BodyStrongTextBlockStyle"/>
-        <StackPanel Orientation="Horizontal" Spacing="4">
+        <StackPanel Orientation="Horizontal" Spacing="8">
           <Label Margin="0,10">Steam launch args</Label>
           <TextBox Watermark="Steam launch args (e.g. -dev)" VerticalContentAlignment="Center" Width="240" Text="{Binding SteamLaunchArgs}"/>
         </StackPanel>
@@ -24,7 +24,7 @@
                    IsReadOnly="True"
                    VerticalContentAlignment="Center"/>
           <Button Margin="5,0,0,0" Command="{Binding OnBrowseSteamCommand}">Browse</Button>
-            <Button Margin="5,0,0,0" Command="{Binding OnResetSteamCommand}">Reset</Button>
+          <Button Margin="5,0,0,0" Command="{Binding OnResetSteamCommand}">Reset</Button>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Margin="0,10" Spacing="4">
           <Label Margin="0,10">Cache directory</Label>

--- a/SFP_UI/Pages/SettingsPage.axaml
+++ b/SFP_UI/Pages/SettingsPage.axaml
@@ -15,11 +15,11 @@
         <TextBlock Text="Steam" Classes="BodyStrongTextBlockStyle"/>
         <StackPanel Orientation="Horizontal" Spacing="4">
           <Label Margin="0,10">Steam Launch Args</Label>
-          <TextBox Watermark="Steam launch args (e.g. -dev)" VerticalContentAlignment="Center" Width="220" Text="{Binding SteamLaunchArgs}"/>
+          <TextBox Watermark="Steam launch args (e.g. -dev)" VerticalContentAlignment="Center" Width="240" Text="{Binding SteamLaunchArgs}"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Margin="0,10" Spacing="4">
           <Label Margin="0,10">Steam Directory</Label>
-          <TextBox Watermark="Steam Directory" Margin="20,0,0,0" Width="220" Text="{Binding SteamDirectory}"
+          <TextBox Watermark="Steam Directory" Margin="20,0,0,0" Width="240" Text="{Binding SteamDirectory}"
                    IsReadOnly="True"
                    VerticalContentAlignment="Center"/>
           <Button Margin="5,0,0,0" Command="{Binding OnBrowseSteamCommand}">Browse</Button>
@@ -27,7 +27,7 @@
         </StackPanel>
         <StackPanel Orientation="Horizontal" Margin="0,10" Spacing="4">
           <Label Margin="0,10">Cache Directory</Label>
-          <TextBox Watermark="Cache Directory" Margin="20,0,0,0" Width="220" Text="{Binding CacheDirectory}"
+          <TextBox Watermark="Cache Directory" Margin="20,0,0,0" Width="240" Text="{Binding CacheDirectory}"
                    IsReadOnly="True"
                    VerticalContentAlignment="Center"/>
           <Button Margin="5,0,0,0" Command="{Binding OnBrowseCacheCommand}">Browse</Button>
@@ -57,7 +57,7 @@
         <CheckBox IsChecked="{Binding StartMinimized}">Start Minimized</CheckBox>
         <!-- <CheckBox IsChecked="{Binding StartWithOS}">Start With OS</CheckBox> -->
         <Label>App Theme</Label>
-        <ComboBox Name="AppThemeComboBox" Width="141" SelectedIndex="2">
+        <ComboBox Name="AppThemeComboBox" Width="200" SelectedIndex="2">
             <ComboBoxItem>Dark</ComboBoxItem>
             <ComboBoxItem>Light</ComboBoxItem>
             <ComboBoxItem>System Default</ComboBoxItem>

--- a/SFP_UI/Pages/SettingsPage.axaml
+++ b/SFP_UI/Pages/SettingsPage.axaml
@@ -15,49 +15,49 @@
 
         <TextBlock Text="Steam" Classes="BodyStrongTextBlockStyle"/>
         <StackPanel Orientation="Horizontal" Spacing="4">
-          <Label Margin="0,10">Steam Launch Args</Label>
+          <Label Margin="0,10">Steam launch args</Label>
           <TextBox Watermark="Steam launch args (e.g. -dev)" VerticalContentAlignment="Center" Width="240" Text="{Binding SteamLaunchArgs}"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Margin="0,10" Spacing="4">
-          <Label Margin="0,10">Steam Directory</Label>
-          <TextBox Watermark="Steam Directory" Margin="20,0,0,0" Width="240" Text="{Binding SteamDirectory}"
+          <Label Margin="0,10">Steam directory</Label>
+          <TextBox Watermark="Steam directory" Margin="20,0,0,0" Width="240" Text="{Binding SteamDirectory}"
                    IsReadOnly="True"
                    VerticalContentAlignment="Center"/>
           <Button Margin="5,0,0,0" Command="{Binding OnBrowseSteamCommand}">Browse</Button>
             <Button Margin="5,0,0,0" Command="{Binding OnResetSteamCommand}">Reset</Button>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Margin="0,10" Spacing="4">
-          <Label Margin="0,10">Cache Directory</Label>
-          <TextBox Watermark="Cache Directory" Margin="20,0,0,0" Width="240" Text="{Binding CacheDirectory}"
+          <Label Margin="0,10">Cache directory</Label>
+          <TextBox Watermark="dache Directory" Margin="20,0,0,0" Width="240" Text="{Binding CacheDirectory}"
                    IsReadOnly="True"
                    VerticalContentAlignment="Center"/>
           <Button Margin="5,0,0,0" Command="{Binding OnBrowseCacheCommand}">Browse</Button>
           <Button Margin="5,0,0,0" Command="{Binding OnResetCacheCommand}">Reset</Button>
         </StackPanel>
-        <CheckBox IsChecked="{Binding RestartSteamOnPatch}">Restart Steam On Patch</CheckBox>
+        <CheckBox IsChecked="{Binding RestartSteamOnPatch}">Restart Steam on patch</CheckBox>
 
         <TextBlock Text="Patcher" Margin="0 20 0 4" Classes="BodyStrongTextBlockStyle"/>
-        <CheckBox IsChecked="{Binding ShouldPatchOnStart}">Patch On App Startup</CheckBox>
-        <CheckBox IsChecked="{Binding ShouldPatchFriends}">Patch Friends</CheckBox>
-        <CheckBox IsChecked="{Binding ShouldPatchLibrary}">Patch Library</CheckBox>
-        <CheckBox IsChecked="{Binding ScanOnly}">Scan Only</CheckBox>
+        <CheckBox IsChecked="{Binding ShouldPatchOnStart}">Patch on app startup</CheckBox>
+        <CheckBox IsChecked="{Binding ShouldPatchFriends}">Patch friends</CheckBox>
+        <CheckBox IsChecked="{Binding ShouldPatchLibrary}">Patch library</CheckBox>
+        <CheckBox IsChecked="{Binding ScanOnly}">Scan only</CheckBox>
 
         <TextBlock Text="Scanner" Margin="0 20 0 4" Classes="BodyStrongTextBlockStyle"/>
-        <CheckBox IsChecked="{Binding ShouldScanOnStart}">Scan On App Startup</CheckBox>
-        <CheckBox IsChecked="{Binding ShouldScanFriends}">Scan Friends</CheckBox>
-        <CheckBox IsChecked="{Binding ShouldScanLibrary}">Scan Library</CheckBox>
+        <CheckBox IsChecked="{Binding ShouldScanOnStart}">Scan on app startup</CheckBox>
+        <CheckBox IsChecked="{Binding ShouldScanFriends}">Scan friends</CheckBox>
+        <CheckBox IsChecked="{Binding ShouldScanLibrary}">Scan library</CheckBox>
         <StackPanel Orientation="Horizontal" Margin="0,5" Spacing="4">
-            <Label>Scanner Delay (Seconds)</Label>
+            <Label>Scanner delay (seconds)</Label>
             <NumericUpDown Value="{Binding ScannerDelay}" Increment="1" Minimum="1" Maximum="10" Width="110" Height="20" HorizontalContentAlignment="Center"/>
         </StackPanel>
 
         <TextBlock Text="General" Margin="0 20 0 4" Classes="BodyStrongTextBlockStyle"/>
-        <CheckBox IsChecked="{Binding CheckForUpdates}">Check For Updates On Startup</CheckBox>
-        <CheckBox IsChecked="{Binding ShowTrayIcon}">Show Tray Icon</CheckBox>
-        <CheckBox IsChecked="{Binding MinimizeToTray}">Minimize To Tray</CheckBox>
-        <CheckBox IsChecked="{Binding StartMinimized}">Start Minimized</CheckBox>
+        <CheckBox IsChecked="{Binding CheckForUpdates}">Check for updates on startup</CheckBox>
+        <CheckBox IsChecked="{Binding ShowTrayIcon}">Show tray icon</CheckBox>
+        <CheckBox IsChecked="{Binding MinimizeToTray}">Minimize to tray</CheckBox>
+        <CheckBox IsChecked="{Binding StartMinimized}">Start minimized</CheckBox>
         <!-- <CheckBox IsChecked="{Binding StartWithOS}">Start With OS</CheckBox> -->
-        <Label>App Theme</Label>
+        <Label>App theme</Label>
         <ComboBox Name="AppThemeComboBox" Width="200" SelectedIndex="2">
             <ComboBoxItem>Dark</ComboBoxItem>
             <ComboBoxItem>Light</ComboBoxItem>

--- a/SFP_UI/Pages/SettingsPage.axaml
+++ b/SFP_UI/Pages/SettingsPage.axaml
@@ -55,6 +55,7 @@
         <CheckBox IsChecked="{Binding CheckForUpdates}">Check for updates on startup</CheckBox>
         <CheckBox IsChecked="{Binding ShowTrayIcon}">Show tray icon</CheckBox>
         <CheckBox IsChecked="{Binding MinimizeToTray}">Minimize to tray</CheckBox>
+        <CheckBox IsChecked="{Binding CloseToTray}">Close to tray</CheckBox>
         <CheckBox IsChecked="{Binding StartMinimized}">Start minimized</CheckBox>
         <!-- <CheckBox IsChecked="{Binding StartWithOS}">Start With OS</CheckBox> -->
         <Label>App theme</Label>

--- a/SFP_UI/Pages/SettingsPage.axaml.cs
+++ b/SFP_UI/Pages/SettingsPage.axaml.cs
@@ -10,7 +10,7 @@ namespace SFP_UI.Pages
         public SettingsPage()
         {
             InitializeComponent();
-            DataContext = new SettingsPageViewModel();
+            DataContext = new SettingsPageViewModel(this.FindControl<ComboBox>("AppThemeComboBox"));
         }
 
         private void InitializeComponent()

--- a/SFP_UI/SFP_UI.csproj
+++ b/SFP_UI/SFP_UI.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Avalonia.Desktop" Version="0.10.15" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.15" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="0.10.15" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.15" />
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="6.0.1" />
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />

--- a/SFP_UI/SFP_UI.csproj
+++ b/SFP_UI/SFP_UI.csproj
@@ -29,9 +29,9 @@
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
     <PackageReference Include="Notification.Avalonia" Version="1.0.1" />
     <PackageReference Include="Semver" Version="2.2.0-rc.0" />
+    <PackageReference Include="FluentAvaloniaUI" Version="1.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SFP\SFP.csproj" />
-    <ProjectReference Include="..\external\FluentAvalonia\FluentAvalonia\FluentAvalonia.csproj" />
   </ItemGroup>
 </Project>

--- a/SFP_UI/SFP_UI.csproj
+++ b/SFP_UI/SFP_UI.csproj
@@ -30,9 +30,9 @@
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
     <PackageReference Include="Notification.Avalonia" Version="1.0.1" />
     <PackageReference Include="Semver" Version="2.2.0-rc.0" />
-    <PackageReference Include="FluentAvaloniaUI" Version="1.4.0" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\external\FluentAvalonia\FluentAvalonia\FluentAvalonia.csproj" />
     <ProjectReference Include="..\SFP\SFP.csproj" />
   </ItemGroup>
 </Project>

--- a/SFP_UI/ViewModels/SettingsPageViewModel.cs
+++ b/SFP_UI/ViewModels/SettingsPageViewModel.cs
@@ -247,7 +247,7 @@ namespace SFP_UI.ViewModels
                 SFP.Properties.Settings.Default.AppTheme = value;
                 if (value == "System Default")
                 {
-                    MainWindow.Instance!.Theme!.InvalidateThemingFromSystemThemeChanged();
+                    MainWindow.Instance?.Theme?.InvalidateThemingFromSystemThemeChanged();
                 }
                 else
                 {

--- a/SFP_UI/ViewModels/SettingsPageViewModel.cs
+++ b/SFP_UI/ViewModels/SettingsPageViewModel.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 using Avalonia.Controls;
 
 using ReactiveUI;
@@ -247,7 +249,14 @@ namespace SFP_UI.ViewModels
                 SFP.Properties.Settings.Default.AppTheme = value;
                 if (value == "System Default")
                 {
-                    MainWindow.Instance?.Theme?.InvalidateThemingFromSystemThemeChanged();
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        MainWindow.Instance?.Theme?.InvalidateThemingFromSystemThemeChanged();
+                    }
+                    else
+                    {
+                        MainWindow.Instance!.Theme!.RequestedTheme = FluentAvalonia.Styling.FluentAvaloniaTheme.DarkModeString;
+                    }
                 }
                 else
                 {

--- a/SFP_UI/ViewModels/SettingsPageViewModel.cs
+++ b/SFP_UI/ViewModels/SettingsPageViewModel.cs
@@ -12,9 +12,22 @@ namespace SFP_UI.ViewModels
     {
         public static SettingsPageViewModel? Instance { get; private set; }
 
-        public SettingsPageViewModel()
+        public SettingsPageViewModel(ComboBox appThemeComboBox)
         {
             Instance = this;
+            appThemeComboBox.SelectionChanged += OnAppThemeSelectedChanged;
+            if (SFP.Properties.Settings.Default.AppTheme == FluentAvalonia.Styling.FluentAvaloniaTheme.DarkModeString)
+            {
+                appThemeComboBox.SelectedIndex = 0;
+            }
+            else if (SFP.Properties.Settings.Default.AppTheme == FluentAvalonia.Styling.FluentAvaloniaTheme.LightModeString)
+            {
+                appThemeComboBox.SelectedIndex = 1;
+            }
+            else
+            {
+                appThemeComboBox.SelectedIndex = 2;
+            }
         }
 
         private bool _shouldPatchOnStart = SFP.Properties.Settings.Default.ShouldPatchOnStart;
@@ -223,6 +236,26 @@ namespace SFP_UI.ViewModels
         }
         */
 
+        private string _appTheme = SFP.Properties.Settings.Default.AppTheme;
+
+        public string AppTheme
+        {
+            get => _appTheme;
+            private set
+            {
+                this.RaiseAndSetIfChanged(ref _appTheme, value);
+                SFP.Properties.Settings.Default.AppTheme = value;
+                if (value == "System Default")
+                {
+                    MainWindow.Instance!.Theme!.InvalidateThemingFromSystemThemeChanged();
+                }
+                else
+                {
+                    MainWindow.Instance!.Theme!.RequestedTheme = value;
+                }
+            }
+        }
+
         public static void OnSaveCommand()
         {
             SFP.Properties.Settings.Default.Save();
@@ -243,6 +276,7 @@ namespace SFP_UI.ViewModels
             SteamLaunchArgs = SFP.Properties.Settings.Default.SteamLaunchArgs;
             CacheDirectory = SteamModel.CacheDir;
             ScannerDelay = SFP.Properties.Settings.Default.ScannerDelay;
+            AppTheme = SFP.Properties.Settings.Default.AppTheme;
         }
 
         public async void OnBrowseSteamCommand()
@@ -275,6 +309,17 @@ namespace SFP_UI.ViewModels
         {
             SFP.Properties.Settings.Default.CacheDirectory = string.Empty;
             CacheDirectory = SteamModel.CacheDir;
+        }
+
+        public void OnAppThemeSelectedChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (sender is ComboBox cb)
+            {
+                if (cb.SelectedItem is ComboBoxItem cbi)
+                {
+                    AppTheme = (string)cbi.Content;
+                }
+            }
         }
     }
 }

--- a/SFP_UI/ViewModels/SettingsPageViewModel.cs
+++ b/SFP_UI/ViewModels/SettingsPageViewModel.cs
@@ -341,12 +341,9 @@ namespace SFP_UI.ViewModels
 
         public void OnAppThemeSelectedChanged(object? sender, SelectionChangedEventArgs e)
         {
-            if (sender is ComboBox cb)
+            if (sender is ComboBox cb && cb.SelectedItem is ComboBoxItem cbi)
             {
-                if (cb.SelectedItem is ComboBoxItem cbi)
-                {
-                    AppTheme = (string)cbi.Content;
-                }
+                AppTheme = (string)cbi.Content;
             }
         }
     }

--- a/SFP_UI/ViewModels/SettingsPageViewModel.cs
+++ b/SFP_UI/ViewModels/SettingsPageViewModel.cs
@@ -200,6 +200,18 @@ namespace SFP_UI.ViewModels
             }
         }
 
+        private bool _closeToTray = SFP.Properties.Settings.Default.CloseToTray;
+
+        public bool CloseToTray
+        {
+            get => _closeToTray;
+            private set
+            {
+                this.RaiseAndSetIfChanged(ref _closeToTray, value);
+                SFP.Properties.Settings.Default.CloseToTray = value;
+            }
+        }
+
         private bool _startMinimized = SFP.Properties.Settings.Default.StartMinimized;
 
         public bool StartMinimized
@@ -288,6 +300,7 @@ namespace SFP_UI.ViewModels
             AppTheme = SFP.Properties.Settings.Default.AppTheme;
             StartMinimized = SFP.Properties.Settings.Default.StartMinimized;
             MinimizeToTray = SFP.Properties.Settings.Default.MinimizeToTray;
+            CloseToTray = SFP.Properties.Settings.Default.CloseToTray;
             CheckForUpdates = SFP.Properties.Settings.Default.CheckForUpdates;
             ShowTrayIcon = SFP.Properties.Settings.Default.ShowTrayIcon;
         }

--- a/SFP_UI/ViewModels/SettingsPageViewModel.cs
+++ b/SFP_UI/ViewModels/SettingsPageViewModel.cs
@@ -286,6 +286,10 @@ namespace SFP_UI.ViewModels
             CacheDirectory = SteamModel.CacheDir;
             ScannerDelay = SFP.Properties.Settings.Default.ScannerDelay;
             AppTheme = SFP.Properties.Settings.Default.AppTheme;
+            StartMinimized = SFP.Properties.Settings.Default.StartMinimized;
+            MinimizeToTray = SFP.Properties.Settings.Default.MinimizeToTray;
+            CheckForUpdates = SFP.Properties.Settings.Default.CheckForUpdates;
+            ShowTrayIcon = SFP.Properties.Settings.Default.ShowTrayIcon;
         }
 
         public async void OnBrowseSteamCommand()

--- a/SFP_UI/ViewModels/SettingsPageViewModel.cs
+++ b/SFP_UI/ViewModels/SettingsPageViewModel.cs
@@ -14,6 +14,8 @@ namespace SFP_UI.ViewModels
     {
         public static SettingsPageViewModel? Instance { get; private set; }
 
+        private static bool s_isWindows { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
         public SettingsPageViewModel(ComboBox appThemeComboBox)
         {
             Instance = this;
@@ -261,7 +263,7 @@ namespace SFP_UI.ViewModels
                 SFP.Properties.Settings.Default.AppTheme = value;
                 if (value == "System Default")
                 {
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    if (s_isWindows)
                     {
                         MainWindow.Instance?.Theme?.InvalidateThemingFromSystemThemeChanged();
                     }

--- a/SFP_UI/Views/MainView.axaml
+++ b/SFP_UI/Views/MainView.axaml
@@ -7,6 +7,10 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SFP_UI.Views.MainView">
 
+    <UserControl.Resources>
+        <Thickness x:Key="NavigationViewContentMargin">0,48,0,0</Thickness>
+    </UserControl.Resources>
+
     <UserControl.Styles>
         <Style Selector="ui|NavigationView.SFPAppNav">
             <Setter Property="OpenPaneLength" Value="240" />

--- a/SFP_UI/Views/MainView.axaml.cs
+++ b/SFP_UI/Views/MainView.axaml.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
@@ -128,6 +130,23 @@ namespace SFP_UI.Views
             if (sender is Window w)
             {
                 w.Opened -= OnParentWindowOpened;
+
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    if (this.FindControl<Grid>("TitleBarHost") is Grid g)
+                    {
+                        g.IsVisible = false;
+                    }
+
+                    string key = "NavigationViewContentMargin";
+                    if (Resources.ContainsKey(key))
+                    {
+                        var newThickness = new Thickness(0, 0, 0, 0);
+                        Resources[key] = newThickness;
+                    }
+
+                    return;
+                }
 
                 if (sender is CoreWindow cw)
                 {

--- a/SFP_UI/Views/MainWindow.axaml.cs
+++ b/SFP_UI/Views/MainWindow.axaml.cs
@@ -108,12 +108,15 @@ namespace SFP_UI.Views
                             }
                         };
                     }
-                    else
+
+                    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !IsValidRequestedTheme(SFP.Properties.Settings.Default.AppTheme))
                     {
-                        if (!IsValidRequestedTheme(SFP.Properties.Settings.Default.AppTheme))
-                        {
-                            Theme.RequestedTheme = FluentAvaloniaTheme.DarkModeString;
-                        }
+                        Theme.RequestedTheme = FluentAvaloniaTheme.DarkModeString;
+                    }
+
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    {
+                        Models.ThemeChangeDetection.Linux.WatchForChanges();
                     }
 
                     Theme.ForceWin32WindowToTheme(this);

--- a/SFP_UI/Views/MainWindow.axaml.cs
+++ b/SFP_UI/Views/MainWindow.axaml.cs
@@ -73,8 +73,7 @@ namespace SFP_UI.Views
                     Theme.RequestedThemeChanged -= OnRequestedThemeChanged;
                     Theme.RequestedThemeChanged += OnRequestedThemeChanged;
 
-                    if (SFP.Properties.Settings.Default.AppTheme == FluentAvaloniaTheme.LightModeString
-                        || SFP.Properties.Settings.Default.AppTheme == FluentAvaloniaTheme.DarkModeString)
+                    if (IsValidRequestedTheme(SFP.Properties.Settings.Default.AppTheme))
                     {
                         Theme.RequestedTheme = SFP.Properties.Settings.Default.AppTheme;
                     }
@@ -110,7 +109,10 @@ namespace SFP_UI.Views
                     }
                     else
                     {
-                        Theme.RequestedTheme = FluentAvaloniaTheme.DarkModeString;
+                        if (!IsValidRequestedTheme(SFP.Properties.Settings.Default.AppTheme))
+                        {
+                            Theme.RequestedTheme = FluentAvaloniaTheme.DarkModeString;
+                        }
                     }
 
                     Theme.ForceWin32WindowToTheme(this);
@@ -210,6 +212,18 @@ namespace SFP_UI.Views
             Show();
             WindowState = WindowState.Normal;
             Activate();
+        }
+
+        public static bool IsValidRequestedTheme(string thm)
+        {
+            if (FluentAvaloniaTheme.LightModeString.Equals(thm, StringComparison.OrdinalIgnoreCase) ||
+                FluentAvaloniaTheme.DarkModeString.Equals(thm, StringComparison.OrdinalIgnoreCase) ||
+                FluentAvaloniaTheme.HighContrastModeString.Equals(thm, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/SFP_UI/Views/MainWindow.axaml.cs
+++ b/SFP_UI/Views/MainWindow.axaml.cs
@@ -73,6 +73,12 @@ namespace SFP_UI.Views
                     Theme.RequestedThemeChanged -= OnRequestedThemeChanged;
                     Theme.RequestedThemeChanged += OnRequestedThemeChanged;
 
+                    if (SFP.Properties.Settings.Default.AppTheme == FluentAvaloniaTheme.LightModeString
+                        || SFP.Properties.Settings.Default.AppTheme == FluentAvaloniaTheme.DarkModeString)
+                    {
+                        Theme.RequestedTheme = SFP.Properties.Settings.Default.AppTheme;
+                    }
+
                     // Enable Mica on Windows 11
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {
@@ -86,11 +92,14 @@ namespace SFP_UI.Views
                         }
                         Microsoft.Win32.SystemEvents.UserPreferenceChanged += (s, e) =>
                         {
+                            if (SFP.Properties.Settings.Default.AppTheme != "System Default")
+                            {
+                                return;
+                            }
+
                             try
                             {
                                 Theme.InvalidateThemingFromSystemThemeChanged();
-                                MainView.SetAppTitleColor();
-                                UpdateCheckModel.UpdateNotificationManagerColors();
                             }
                             catch (Exception err)
                             {
@@ -127,6 +136,9 @@ namespace SFP_UI.Views
                     SetValue(BackgroundProperty, AvaloniaProperty.UnsetValue);
                 }
             }
+
+            MainView.SetAppTitleColor();
+            UpdateCheckModel.UpdateNotificationManagerColors();
         }
 
         private void TryEnableMicaEffect(FluentAvaloniaTheme thm)

--- a/SFP_UI/Views/MainWindow.axaml.cs
+++ b/SFP_UI/Views/MainWindow.axaml.cs
@@ -74,9 +74,14 @@ namespace SFP_UI.Views
                     Theme.RequestedThemeChanged -= OnRequestedThemeChanged;
                     Theme.RequestedThemeChanged += OnRequestedThemeChanged;
 
+                    Theme.RequestedTheme = FluentAvaloniaTheme.DarkModeString; // Default to dark mode
                     if (IsValidRequestedTheme(SFP.Properties.Settings.Default.AppTheme))
                     {
                         Theme.RequestedTheme = SFP.Properties.Settings.Default.AppTheme;
+                    }
+                    else
+                    {
+                        Theme.InvalidateThemingFromSystemThemeChanged();
                     }
 
                     // Enable Mica on Windows 11
@@ -107,11 +112,6 @@ namespace SFP_UI.Views
                                 SFP.LogModel.Logger.Error(err);
                             }
                         };
-                    }
-
-                    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !IsValidRequestedTheme(SFP.Properties.Settings.Default.AppTheme))
-                    {
-                        Theme.RequestedTheme = FluentAvaloniaTheme.DarkModeString;
                     }
 
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))

--- a/SFP_UI/Views/MainWindow.axaml.cs
+++ b/SFP_UI/Views/MainWindow.axaml.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 
 using Avalonia;
@@ -118,6 +119,19 @@ namespace SFP_UI.Views
                     Theme.ForceWin32WindowToTheme(this);
                 }
             }
+        }
+
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            if (!SFP.Properties.Settings.Default.CloseToTray || !SFP.Properties.Settings.Default.ShowTrayIcon)
+            {
+                base.OnClosing(e);
+                return;
+            }
+
+            SFP.LogModel.Logger.Debug("Closing to tray");
+            Hide();
+            e.Cancel = true;
         }
 
         private void OnRequestedThemeChanged(FluentAvaloniaTheme sender, RequestedThemeChangedEventArgs args)

--- a/createpublishedzip.ps1
+++ b/createpublishedzip.ps1
@@ -1,7 +1,8 @@
 param(
     [String]$os="win10;linux;osx",
     [String]$arch="x64",
-    [String]$configuration="Release"
+    [String]$configuration="Release",
+    [bool]$createzip="True"
     )
 
 function Build-SFP {
@@ -11,7 +12,10 @@ function Build-SFP {
 
     Remove-Item -Path "./$configuration/publish" -Recurse -Force -ErrorAction Ignore
     dotnet publish "SFP_UI/SFP_UI.csproj" --configuration $configuration --output $configuration/publish --self-contained --runtime $targetRuntime
-    Get-ChildItem "./$configuration/publish/*" -Recurse -Exclude SFP.config,*.log,FluentAvalonia.pdb | Compress-Archive -DestinationPath "./$configuration/SFP_UI-SelfContained-$targetRuntime.zip" -Force
+    if ($createzip)
+    {
+        Get-ChildItem "./$configuration/publish/*" -Recurse -Exclude SFP.config,*.log,FluentAvalonia.pdb | Compress-Archive -DestinationPath "./$configuration/SFP_UI-SelfContained-$targetRuntime.zip" -Force
+    }
 }
 
 foreach ($currentOS in $os.Split(";"))


### PR DESCRIPTION
# Changes

- Fixed additional crashes
- Removed log spam
- Added option to specify app theme
- Fixed issue that caused the scanner delay option to not apply until SFP was restarted

## Linux / OSX

- Removed duplicate titlebar
- Now SFP can follow the system theme on Linux and OSX. SFP on Mac will only detect the system theme on launch.