### PR TITLE
0.0.48

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SFP (Formerly SteamFriendsPatcher)
 
-This utility allows you to apply themes and scripts to the new Steam client.
+This utility allows you to apply skins and scripts to the new Steam client.
 
 - [SFP (Formerly SteamFriendsPatcher)](#sfp--formerly-steamfriendspatcher-)
     * [Instructions](#instructions)
@@ -205,7 +205,7 @@ visit <http://localhost:8080> in your web browser.
 
 ## Todo
 
-- Add ability to install and customize themes directly from SFP
+- Add ability to install and customize skins directly from SFP
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SFP (Formerly SteamFriendsPatcher)
 
-This utility allows you to apply themes and scripts to the new Steam beta client.
+This utility allows you to apply themes and scripts to the new Steam client.
 
 ## Instructions
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,14 @@ visit <http://localhost:8080> in your web browser.
 
 ## Dependencies
 
+### All
+
 - [.NET 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) (Only if not using self contained version)
+
+### Linux
+
+- ttf-ms-fonts
+  -  run `fc-cache --force` after installing
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ This utility allows you to apply skins and scripts to the new Steam client.
     - This setting is enabled by default
 6. Use the "Open File" button in SFP to access the files where your custom skins and scripts are applied from.
 
+For more information and links to existing skins see [Steam Skins Wiki](https://steamskins.pages.dev/)
+
 ## Features
 
 ### Steam Skinning

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 This utility allows you to apply themes and scripts to the new Steam client.
 
+- [SFP (Formerly SteamFriendsPatcher)](#sfp--formerly-steamfriendspatcher-)
+    * [Instructions](#instructions)
+    * [Features](#features)
+        + [Steam Skinning](#steam-skinning)
+        + [Scripting](#scripting)
+        + [Skins and Scripts in Separate Folders](#skins-and-scripts-in-separate-folders)
+        + [Enable JavaScript Injection](#enable-javascript-injection)
+    * [Skin Authors](#skin-authors)
+        + [Matching against pages with variable titles](#matching-against-pages-with-variable-titles)
+        + [Finding Steam Page Titles](#finding-steam-page-titles)
+    * [Todo](#todo)
+    * [Known Issues](#known-issues)
+    * [Dependencies](#dependencies)
+        + [All](#all)
+        + [Linux](#linux)
+    * [Credits](#credits)
+
+<small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
+
 ## Instructions
 
 1. Download and extract the [latest zip file under Releases](https://github.com/PhantomGamers/SFP/releases/) for your

--- a/README.md
+++ b/README.md
@@ -69,11 +69,6 @@ Default `skin.json`:
       "TargetJs": "webkit.js"
     },
     {
-      "MatchRegexString": ".friendsui-container",
-      "TargetCss": "friends.custom.css",
-      "TargetJs": "friends.custom.js"
-    },
-    {
       "MatchRegexString": "^Steam$",
       "TargetCss": "libraryroot.custom.css",
       "TargetJs": "libraryroot.custom.js"
@@ -85,11 +80,6 @@ Default `skin.json`:
     },
     {
       "MatchRegexString": "^SP Overlay:",
-      "TargetCss": "libraryroot.custom.css",
-      "TargetJs": "libraryroot.custom.js"
-    },
-    {
-      "MatchRegexString": "Menu$",
       "TargetCss": "libraryroot.custom.css",
       "TargetJs": "libraryroot.custom.js"
     },
@@ -127,6 +117,16 @@ Default `skin.json`:
       "MatchRegexString": "^MainMenu_",
       "TargetCss": "bigpicture.custom.css",
       "TargetJs": "bigpicture.custom.js"
+    },
+    {
+      "MatchRegexString": ".friendsui-container",
+      "TargetCss": "friends.custom.css",
+      "TargetJs": "friends.custom.js"
+    },
+    {
+      "MatchRegexString": "Menu$",
+      "TargetCss": "libraryroot.custom.css",
+      "TargetJs": "libraryroot.custom.js"
     },
     {
       "MatchRegexString": ".ModalDialogPopup",

--- a/SFP/App.config
+++ b/SFP/App.config
@@ -64,6 +64,9 @@
             <setting name="DumpPages" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="UseAppTheme" serializeAs="String">
+                <value>True</value>
+            </setting>
         </SFP.Properties.Settings>
     </userSettings>
 </configuration>

--- a/SFP/Models/Injection/Config/SfpConfig.cs
+++ b/SFP/Models/Injection/Config/SfpConfig.cs
@@ -50,11 +50,6 @@ public class SfpConfig
             MatchRegexString = "https://store.steampowered.com", TargetCss = "webkit.css", TargetJs = "webkit.js"
         },
         new PatchEntry { MatchRegexString = "https://steamcommunity.com", TargetCss = "webkit.css", TargetJs = "webkit.js" },
-        // Friends List and Chat
-        new PatchEntry
-        {
-            MatchRegexString = @".friendsui-container", TargetCss = "friends.custom.css", TargetJs = "friends.custom.js"
-        },
         new PatchEntry
         {
             MatchRegexString = "^Steam$", TargetCss = "libraryroot.custom.css", TargetJs = "libraryroot.custom.js"
@@ -69,7 +64,6 @@ public class SfpConfig
         {
             MatchRegexString = "^SP Overlay:", TargetCss = "libraryroot.custom.css", TargetJs = "libraryroot.custom.js"
         },
-        new PatchEntry { MatchRegexString = "Menu$", TargetCss = "libraryroot.custom.css", TargetJs = "libraryroot.custom.js" },
         new PatchEntry
         {
             MatchRegexString = @"Supernav$", TargetCss = "libraryroot.custom.css", TargetJs = "libraryroot.custom.js"
@@ -106,6 +100,12 @@ public class SfpConfig
         {
             MatchRegexString = "^MainMenu_", TargetCss = "bigpicture.custom.css", TargetJs = "bigpicture.custom.js"
         },
+        // Friends List and Chat
+        new PatchEntry
+        {
+            MatchRegexString = @".friendsui-container", TargetCss = "friends.custom.css", TargetJs = "friends.custom.js"
+        },
+        new PatchEntry { MatchRegexString = "Menu$", TargetCss = "libraryroot.custom.css", TargetJs = "libraryroot.custom.js" },
         new PatchEntry
         {
             // Steam Dialog popups (Settings, Game Properties, etc)

--- a/SFP/Models/Injection/Injector.cs
+++ b/SFP/Models/Injection/Injector.cs
@@ -19,6 +19,8 @@ public static partial class Injector
 
     public static event EventHandler? InjectionStateChanged;
 
+    private static string PreferredColorScheme { get; set; } = "light";
+
     public static async Task StartInjectionAsync(bool noError = false)
     {
         if (s_browser is { IsConnected: true })
@@ -184,6 +186,11 @@ public static partial class Injector
         if (page == null)
         {
             return;
+        }
+
+        if (Settings.Default.UseAppTheme)
+        {
+            await UpdateColorInPage(page);
         }
 
         page.FrameNavigated -= Frame_Navigate;
@@ -414,6 +421,45 @@ public static partial class Injector
     private static bool IsFrameWebkit(Frame frame)
     {
         return !frame.Url.StartsWith("https://steamloopback.host");
+    }
+
+    private static async Task UpdateColorInPage(Page page)
+    {
+        try
+        {
+            await page.EmulateMediaFeaturesAsync(new[]
+                { new MediaFeatureValue { MediaFeature = MediaFeature.PrefersColorScheme, Value = PreferredColorScheme } });
+        }
+        catch (PuppeteerException e)
+        {
+            Log.Logger.Error(e);
+        }
+    }
+
+    public static async void UpdateColorScheme(string? colorScheme = null)
+    {
+        if (s_browser == null || !Settings.Default.UseAppTheme && colorScheme == null)
+        {
+            return;
+        }
+
+        var tmpColorScheme = PreferredColorScheme;
+        PreferredColorScheme = colorScheme ?? PreferredColorScheme;
+
+        var pages = await s_browser.PagesAsync();
+        var processTasks = pages.Select(UpdateColorInPage);
+        await Task.WhenAll(processTasks);
+
+        PreferredColorScheme = tmpColorScheme;
+    }
+
+    public static void SetColorScheme(string themeVariant)
+    {
+        PreferredColorScheme = themeVariant.ToLower() switch
+        {
+            "dark" => "dark",
+            _ => "light"
+        };
     }
 
     [GeneratedRegex(@"^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?([^:\/?\n]+)")]

--- a/SFP/Models/Injection/Injector.cs
+++ b/SFP/Models/Injection/Injector.cs
@@ -93,6 +93,7 @@ public static partial class Injector
         var pages = await s_browser.PagesAsync();
         Log.Logger.Info("Found " + pages.Length + " pages");
 
+        _ = SfpConfig.GetConfig();
         var processTasks = pages.Select(ProcessPage);
 
         await Task.WhenAll(processTasks);

--- a/SFP/Models/Steam.cs
+++ b/SFP/Models/Steam.cs
@@ -337,8 +337,6 @@ public static class Steam
                 var argumentsMissing = await CheckForMissingArgumentsAsync();
                 if (argumentsMissing)
                 {
-                    s_injectOnce = true;
-                    Log.Logger.Warn("Steam is missing arguments, restarting Steam to fix...");
                     return;
                 }
             }
@@ -397,6 +395,7 @@ public static class Steam
             return false;
         }
 
+        s_injectOnce = true;
         Log.Logger.Info("Steam process detected with missing launch arguments, restarting...");
         await RestartSteam();
         return true;

--- a/SFP/Models/Steam.cs
+++ b/SFP/Models/Steam.cs
@@ -383,7 +383,7 @@ public static class Steam
 
         var args = Settings.Default.SteamLaunchArgs.Trim().ToLower();
         const string DebuggingString = @"-cef-enable-debugging";
-        if (!args.Contains(DebuggingString))
+        if (!args.Split(' ', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).Contains(DebuggingString))
         {
             args += $" {DebuggingString}";
             args = args.Trim();

--- a/SFP/Properties/Settings.Designer.cs
+++ b/SFP/Properties/Settings.Designer.cs
@@ -268,5 +268,18 @@ namespace SFP.Properties {
                 this["DumpPages"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public bool UseAppTheme {
+            get {
+                return ((bool)(this["UseAppTheme"]));
+            }
+            set {
+                this["UseAppTheme"] = value;
+            }
+        }
     }
 }

--- a/SFP/Properties/Settings.settings
+++ b/SFP/Properties/Settings.settings
@@ -59,5 +59,8 @@
     <Setting Name="DumpPages" Roaming="true" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="UseAppTheme" Roaming="true" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/SFP_UI/App.axaml.cs
+++ b/SFP_UI/App.axaml.cs
@@ -1,7 +1,6 @@
 #region
 
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -9,8 +8,8 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using FluentAvalonia.Styling;
-using ReactiveUI;
 using SFP.Models;
+using SFP.Models.Injection;
 using SFP.Properties;
 using SFP_UI.Models;
 using SFP_UI.ViewModels;
@@ -42,6 +41,13 @@ public class App : Application
         base.OnFrameworkInitializationCompleted();
 
         SetIconsState(Settings.Default.ShowTrayIcon);
+
+        Injector.SetColorScheme(ActualThemeVariant.ToString());
+        ActualThemeVariantChanged += (_, _) =>
+        {
+            Injector.SetColorScheme(ActualThemeVariant.ToString());
+            Injector.UpdateColorScheme();
+        };
 
         await HandleStartupTasks();
 

--- a/SFP_UI/App.axaml.cs
+++ b/SFP_UI/App.axaml.cs
@@ -40,6 +40,11 @@ public class App : Application
 
         base.OnFrameworkInitializationCompleted();
 
+        if (Design.IsDesignMode)
+        {
+            return;
+        }
+
         SetIconsState(Settings.Default.ShowTrayIcon);
 
         Injector.SetColorScheme(ActualThemeVariant.ToString());

--- a/SFP_UI/App.axaml.cs
+++ b/SFP_UI/App.axaml.cs
@@ -77,7 +77,7 @@ public class App : Application
         }
     }
 
-    private static void SetIconsState(bool state)
+    public static void SetIconsState(bool state)
     {
         var icons = TrayIcon.GetIcons(Current!);
         if (icons == null)

--- a/SFP_UI/Pages/SettingsPage.axaml
+++ b/SFP_UI/Pages/SettingsPage.axaml
@@ -53,6 +53,7 @@
                 <CheckBox IsChecked="{Binding ForceSteamArgs}">Force Steam arguments</CheckBox>
                 <CheckBox IsChecked="{Binding InjectCss}">Inject CSS</CheckBox>
                 <CheckBox IsChecked="{Binding InjectJs}">Inject JavaScript</CheckBox>
+                <CheckBox IsChecked="{Binding UseAppTheme}">Use App Theme</CheckBox>
                 <CheckBox IsChecked="{Binding DumpPages}">For Skin Authors: Dump Pages</CheckBox>
                 <Separator Margin="0,10" />
 

--- a/SFP_UI/Program.cs
+++ b/SFP_UI/Program.cs
@@ -3,6 +3,7 @@
 using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Media;
 using Avalonia.ReactiveUI;
 using Avalonia.Threading;
 using Bluegrams.Application;
@@ -14,6 +15,7 @@ using SFP.Properties;
 using SFP_UI.Models;
 using SFP_UI.Targets;
 using SFP_UI.Views;
+using SkiaSharp;
 
 #endregion
 
@@ -118,7 +120,9 @@ internal static class Program
         return AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .LogToTrace()
-            .UseReactiveUI();
+            .UseReactiveUI()
+            .With(new Win32PlatformOptions { OverlayPopups = true })
+            .With(new FontManagerOptions { DefaultFamilyName = SKTypeface.Default.FamilyName ?? "Century Schoolbook" });
     }
 
     private static void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)

--- a/SFP_UI/ViewModels/SettingsPageViewModel.cs
+++ b/SFP_UI/ViewModels/SettingsPageViewModel.cs
@@ -76,6 +76,7 @@ public class SettingsPageViewModel : ViewModelBase
         this.WhenAnyValue(x => x.ShowTrayIcon)
             .Subscribe(value =>
             {
+                App.SetIconsState(value);
                 Settings.Default.ShowTrayIcon = value;
                 Settings.Default.Save();
             });

--- a/SFP_UI/ViewModels/SettingsPageViewModel.cs
+++ b/SFP_UI/ViewModels/SettingsPageViewModel.cs
@@ -7,6 +7,7 @@ using FluentAvalonia.UI.Controls;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 using SFP.Models;
+using SFP.Models.Injection;
 using SFP.Properties;
 using SFP_UI.Views;
 using Utils = SFP.Models.Windows.Utils;
@@ -53,6 +54,8 @@ public class SettingsPageViewModel : ViewModelBase
     [Reactive] public bool InjectCss { get; set; }
 
     [Reactive] public bool InjectJs { get; set; }
+
+    [Reactive] public bool UseAppTheme { get; set; }
 
     [Reactive] public bool DumpPages { get; set; }
     #endregion
@@ -186,6 +189,21 @@ public class SettingsPageViewModel : ViewModelBase
                 }
             });
 
+        this.WhenAnyValue(x => x.UseAppTheme)
+            .Subscribe(value =>
+            {
+                Settings.Default.UseAppTheme = value;
+                Settings.Default.Save();
+                if (!value)
+                {
+                    Injector.UpdateColorScheme("light");
+                }
+                else
+                {
+                    Injector.UpdateColorScheme();
+                }
+            });
+
         this.WhenAnyValue(x => x.DumpPages)
             .Subscribe(value =>
             {
@@ -230,6 +248,7 @@ public class SettingsPageViewModel : ViewModelBase
         ForceSteamArgs = Settings.Default.ForceSteamArgs;
         InjectCss = Settings.Default.InjectCSS;
         InjectJs = Settings.Default.InjectJS;
+        UseAppTheme = Settings.Default.UseAppTheme;
         DumpPages = Settings.Default.DumpPages;
         #endregion
 


### PR DESCRIPTION
## Changes

- Added option to force Steam's `prefer-color-scheme` property to follow SFP's app theme
- Fixed issue where the current skin's config would be retrieved multiple times on initial injection
- Fixed issue where `-cef-enable-debugging` would not be added if it was incorrectly but fully included in the launch args
- Fixed issue where the Show Tray Icon setting would not take effect until SFP was restarted
- Fixed issue where the friends list patch was applying to big picture mode in the default skin config
- Possibly fixed crashing on certain Linux machines with missing fonts